### PR TITLE
Add visit device link

### DIFF
--- a/custom_components/espsomfy_rts/entity.py
+++ b/custom_components/espsomfy_rts/entity.py
@@ -24,6 +24,7 @@ class ESPSomfyEntity(CoordinatorEntity[ESPSomfyController], Entity):
     def device_info(self) -> DeviceInfo | None:
         """Device info."""
         return DeviceInfo(
+            configuration_url=f"http://{self.controller.api.get_data()['host']}",
             identifiers={(DOMAIN, self.controller.unique_id)},
             name="ESPSomfy RTS",
             manufacturer=MANUFACTURER,


### PR DESCRIPTION
As the title says:

![image](https://github.com/chemelli74/ESPSomfy-RTS-HA/assets/57354320/d8a03f41-95d4-479b-8f6d-d471f1c9b461)


P.S.> Maybe would be better to add a property "**ip_address**" to `ESPSomfyController`:

